### PR TITLE
Add Prisma user model with CRUD endpoints and login UI

### DIFF
--- a/pos-web-taller-ia/src/app/api/auth/login/route.js
+++ b/pos-web-taller-ia/src/app/api/auth/login/route.js
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import prisma from "../../../../lib/prisma";
+import { verifyPassword } from "../../../../lib/auth";
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { correo, password } = body ?? {};
+
+    if (!correo || !password) {
+      return NextResponse.json(
+        { message: "Debe proporcionar correo y contraseña." },
+        { status: 400 },
+      );
+    }
+
+    const user = await prisma.users.findUnique({
+      where: { correo },
+      select: {
+        user_id: true,
+        correo: true,
+        password: true,
+        nombreUsuario: true,
+        activo: true,
+        fechaCreacion: true,
+      },
+    });
+
+    if (!user || !verifyPassword(password, user.password)) {
+      return NextResponse.json(
+        { message: "Credenciales inválidas." },
+        { status: 401 },
+      );
+    }
+
+    if (!user.activo) {
+      return NextResponse.json(
+        { message: "El usuario está inactivo. Contacte al administrador." },
+        { status: 403 },
+      );
+    }
+
+    return NextResponse.json({
+      message: "Inicio de sesión exitoso.",
+      usuario: {
+        id: user.user_id,
+        correo: user.correo,
+        nombreUsuario: user.nombreUsuario,
+        activo: user.activo,
+        fechaCreacion: user.fechaCreacion,
+      },
+      puerto: process.env.PORT ?? "3000",
+    });
+  } catch (error) {
+    console.error("Error al iniciar sesión", error);
+    return NextResponse.json(
+      { message: "No se pudo completar el inicio de sesión." },
+      { status: 500 },
+    );
+  }
+}

--- a/pos-web-taller-ia/src/app/api/users/[id]/route.js
+++ b/pos-web-taller-ia/src/app/api/users/[id]/route.js
@@ -1,0 +1,173 @@
+import { NextResponse } from "next/server";
+import prisma from "../../../../lib/prisma";
+import { hashPassword } from "../../../../lib/auth";
+
+function parseUserId(id) {
+  const parsed = Number(id);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+function mapUser(user) {
+  if (!user) return null;
+
+  return {
+    id: user.user_id,
+    correo: user.correo,
+    nombreUsuario: user.nombreUsuario,
+    activo: user.activo,
+    fechaCreacion: user.fechaCreacion,
+  };
+}
+
+function resolveActivoInput(value) {
+  if (value === undefined) return undefined;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+
+    if (normalized === "true" || normalized === "1") return true;
+    if (normalized === "false" || normalized === "0") return false;
+  }
+
+  return undefined;
+}
+
+export async function GET(_request, { params }) {
+  const userId = parseUserId(params?.id);
+
+  if (userId === null) {
+    return NextResponse.json({ message: "Identificador inválido." }, { status: 400 });
+  }
+
+  try {
+    const user = await prisma.users.findUnique({
+      where: { user_id: userId },
+      select: {
+        user_id: true,
+        correo: true,
+        nombreUsuario: true,
+        activo: true,
+        fechaCreacion: true,
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json({ message: "Usuario no encontrado." }, { status: 404 });
+    }
+
+    return NextResponse.json(mapUser(user));
+  } catch (error) {
+    console.error("Error al obtener usuario", error);
+    return NextResponse.json(
+      { message: "No se pudo obtener el usuario." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(request, { params }) {
+  const userId = parseUserId(params?.id);
+
+  if (userId === null) {
+    return NextResponse.json({ message: "Identificador inválido." }, { status: 400 });
+  }
+
+  try {
+    const body = await request.json();
+    const { correo, password, nombreUsuario, activo } = body ?? {};
+
+    const data = {};
+
+    if (correo !== undefined) data.correo = correo;
+    if (nombreUsuario !== undefined) data.nombreUsuario = nombreUsuario;
+    if (password) data.password = hashPassword(password);
+
+    const activoValue = resolveActivoInput(activo);
+
+    if (activo !== undefined && activoValue === undefined) {
+      return NextResponse.json(
+        { message: "El campo 'activo' debe ser booleano, 1/0 o true/false." },
+        { status: 400 },
+      );
+    }
+
+    if (activoValue !== undefined) {
+      data.activo = activoValue;
+    }
+
+    if (Object.keys(data).length === 0) {
+      return NextResponse.json(
+        { message: "Debe proporcionar al menos un campo para actualizar." },
+        { status: 400 },
+      );
+    }
+
+    const updatedUser = await prisma.users.update({
+      where: { user_id: userId },
+      data,
+      select: {
+        user_id: true,
+        correo: true,
+        nombreUsuario: true,
+        activo: true,
+        fechaCreacion: true,
+      },
+    });
+
+    return NextResponse.json(mapUser(updatedUser));
+  } catch (error) {
+    console.error("Error al actualizar usuario", error);
+
+    if (error.code === "P2002") {
+      return NextResponse.json(
+        { message: "Ya existe un usuario con ese correo." },
+        { status: 409 },
+      );
+    }
+
+    if (error.code === "P2025") {
+      return NextResponse.json(
+        { message: "Usuario no encontrado." },
+        { status: 404 },
+      );
+    }
+
+    const statusCode =
+      typeof error.message === "string" && error.message.includes("contraseña")
+        ? 400
+        : 500;
+
+    return NextResponse.json(
+      { message: error.message ?? "No se pudo actualizar el usuario." },
+      { status: statusCode },
+    );
+  }
+}
+
+export async function DELETE(_request, { params }) {
+  const userId = parseUserId(params?.id);
+
+  if (userId === null) {
+    return NextResponse.json({ message: "Identificador inválido." }, { status: 400 });
+  }
+
+  try {
+    await prisma.users.delete({ where: { user_id: userId } });
+    return NextResponse.json({ message: "Usuario eliminado correctamente." });
+  } catch (error) {
+    console.error("Error al eliminar usuario", error);
+
+    if (error.code === "P2025") {
+      return NextResponse.json(
+        { message: "Usuario no encontrado." },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      { message: "No se pudo eliminar el usuario." },
+      { status: 500 },
+    );
+  }
+}

--- a/pos-web-taller-ia/src/app/api/users/route.js
+++ b/pos-web-taller-ia/src/app/api/users/route.js
@@ -1,0 +1,114 @@
+import { NextResponse } from "next/server";
+import prisma from "../../../lib/prisma";
+import { hashPassword } from "../../../lib/auth";
+
+function mapUser(user) {
+  if (!user) return null;
+
+  return {
+    id: user.user_id,
+    correo: user.correo,
+    nombreUsuario: user.nombreUsuario,
+    activo: user.activo,
+    fechaCreacion: user.fechaCreacion,
+  };
+}
+
+function resolveActivoInput(value) {
+  if (value === undefined) return undefined;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+
+    if (normalized === "true" || normalized === "1") return true;
+    if (normalized === "false" || normalized === "0") return false;
+  }
+
+  return undefined;
+}
+
+export async function GET() {
+  try {
+    const users = await prisma.users.findMany({
+      orderBy: { user_id: "desc" },
+      select: {
+        user_id: true,
+        correo: true,
+        nombreUsuario: true,
+        activo: true,
+        fechaCreacion: true,
+      },
+    });
+
+    return NextResponse.json(users.map(mapUser));
+  } catch (error) {
+    console.error("Error al listar usuarios", error);
+    return NextResponse.json(
+      { message: "No se pudieron obtener los usuarios." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { correo, password, nombreUsuario, activo } = body ?? {};
+
+    if (!correo || !password || !nombreUsuario) {
+      return NextResponse.json(
+        { message: "Correo, contraseña y nombre de usuario son obligatorios." },
+        { status: 400 },
+      );
+    }
+
+    const activoValue = resolveActivoInput(activo);
+
+    if (activo !== undefined && activoValue === undefined) {
+      return NextResponse.json(
+        { message: "El campo 'activo' debe ser booleano, 1/0 o true/false." },
+        { status: 400 },
+      );
+    }
+
+    const hashedPassword = hashPassword(password);
+
+    const newUser = await prisma.users.create({
+      data: {
+        correo,
+        password: hashedPassword,
+        nombreUsuario,
+        activo: activoValue ?? true,
+      },
+      select: {
+        user_id: true,
+        correo: true,
+        nombreUsuario: true,
+        activo: true,
+        fechaCreacion: true,
+      },
+    });
+
+    return NextResponse.json(mapUser(newUser), { status: 201 });
+  } catch (error) {
+    console.error("Error al crear usuario", error);
+
+    if (error.code === "P2002") {
+      return NextResponse.json(
+        { message: "Ya existe un usuario con ese correo." },
+        { status: 409 },
+      );
+    }
+
+    const statusCode =
+      typeof error.message === "string" && error.message.includes("contraseña")
+        ? 400
+        : 500;
+
+    return NextResponse.json(
+      { message: error.message ?? "No se pudo crear el usuario." },
+      { status: statusCode },
+    );
+  }
+}

--- a/pos-web-taller-ia/src/app/page.js
+++ b/pos-web-taller-ia/src/app/page.js
@@ -1,103 +1,158 @@
-import Image from "next/image";
+"use client";
+
+import { useState } from "react";
 
 export default function Home() {
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.js
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [correo, setCorreo] = useState("");
+  const [password, setPassword] = useState("");
+  const [recordar, setRecordar] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [mensaje, setMensaje] = useState("");
+  const [error, setError] = useState("");
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setLoading(true);
+    setMensaje("");
+    setError("");
+
+    try {
+      const response = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ correo, password, recordar }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data?.message ?? "No se pudo iniciar sesión.");
+      }
+
+      setMensaje(
+        `Bienvenido ${data.usuario?.nombreUsuario ?? ""}. Puerto activo: ${data.puerto}`,
+      );
+    } catch (err) {
+      setError(err.message ?? "Ocurrió un error inesperado.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.15),_transparent_60%),radial-gradient(circle_at_bottom,_rgba(168,85,247,0.12),_transparent_55%)]" />
+
+      <div className="relative z-10 flex min-h-screen items-center justify-center px-6 py-12">
+        <div className="w-full max-w-4xl grid gap-12 rounded-3xl bg-slate-900/70 p-10 shadow-2xl backdrop-blur-md sm:grid-cols-[1.1fr_1fr]">
+          <div className="hidden flex-col justify-between text-slate-200 sm:flex">
+            <div>
+              <p className="text-sm uppercase tracking-[0.3em] text-cyan-300">Panel Administrativo</p>
+              <h1 className="mt-4 text-4xl font-semibold leading-tight">
+                Controla tus usuarios y ventas con una sola plataforma.
+              </h1>
+              <p className="mt-6 text-base text-slate-300">
+                Accede al panel centralizado para gestionar inventario, ventas y reportes en cuestión de segundos.
+                Refuerza la seguridad de tu operación con credenciales únicas y auditorías automáticas.
+              </p>
+            </div>
+
+            <div className="rounded-2xl border border-slate-700/60 bg-slate-900/50 p-6">
+              <p className="text-sm font-medium text-slate-200">¿Necesitas una cuenta?</p>
+              <p className="mt-2 text-sm text-slate-400">
+                Contacta al equipo de TI para habilitar tu usuario o restablecer el acceso de tu equipo.
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-800/60 bg-slate-950/50 p-8 shadow-lg">
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-2xl font-semibold text-white">Iniciar sesión</h2>
+                <p className="mt-1 text-sm text-slate-400">
+                  Ingresa tus credenciales corporativas para continuar.
+                </p>
+              </div>
+              <span className="rounded-full border border-cyan-500/40 bg-cyan-500/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] text-cyan-200">
+                Acceso seguro
+              </span>
+            </div>
+
+            <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+              {mensaje && (
+                <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+                  {mensaje}
+                </div>
+              )}
+
+              {error && (
+                <div className="rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+                  {error}
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-200" htmlFor="correo">
+                  Correo corporativo
+                </label>
+                <input
+                  id="correo"
+                  type="email"
+                  required
+                  autoComplete="email"
+                  value={correo}
+                  onChange={(event) => setCorreo(event.target.value)}
+                  className="w-full rounded-xl border border-slate-800 bg-slate-900/80 px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-cyan-400 focus:ring-2 focus:ring-cyan-500/40"
+                  placeholder="tu.nombre@empresa.com"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-200" htmlFor="password">
+                  Contraseña
+                </label>
+                <input
+                  id="password"
+                  type="password"
+                  required
+                  autoComplete="current-password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  className="w-full rounded-xl border border-slate-800 bg-slate-900/80 px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-cyan-400 focus:ring-2 focus:ring-cyan-500/40"
+                  placeholder="••••••••"
+                />
+              </div>
+
+              <div className="flex items-center justify-between text-sm">
+                <label className="flex items-center gap-2 text-slate-300">
+                  <input
+                    type="checkbox"
+                    checked={recordar}
+                    onChange={(event) => setRecordar(event.target.checked)}
+                    className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-cyan-500 focus:ring-cyan-500"
+                  />
+                  Recordar este dispositivo
+                </label>
+                <a className="text-sm font-medium text-cyan-300 transition hover:text-cyan-200" href="#">
+                  ¿Olvidaste tu contraseña?
+                </a>
+              </div>
+
+              <button
+                type="submit"
+                disabled={loading}
+                className="flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-cyan-500 via-sky-500 to-violet-500 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-cyan-500/25 transition hover:from-cyan-400 hover:via-sky-500 hover:to-violet-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/40 disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                {loading ? "Verificando credenciales..." : "Entrar al panel"}
+              </button>
+            </form>
+
+            <p className="mt-8 text-center text-xs text-slate-500">
+              Acceso cifrado y monitoreado. Si detectas algún inconveniente con tu inicio de sesión comunícate con la mesa de ayuda.
+            </p>
+          </div>
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+      </div>
     </div>
   );
 }

--- a/pos-web-taller-ia/src/lib/auth.js
+++ b/pos-web-taller-ia/src/lib/auth.js
@@ -1,0 +1,34 @@
+import { randomBytes, scryptSync, timingSafeEqual } from "crypto";
+
+const KEY_LENGTH = 64;
+
+export function hashPassword(password) {
+  if (typeof password !== "string" || password.length < 8) {
+    throw new Error("La contraseña debe tener al menos 8 caracteres.");
+  }
+
+  const salt = randomBytes(16).toString("hex");
+  const derivedKey = scryptSync(password, salt, KEY_LENGTH);
+  return `${salt}:${derivedKey.toString("hex")}`;
+}
+
+export function verifyPassword(password, storedHash) {
+  if (typeof password !== "string" || !storedHash) {
+    return false;
+  }
+
+  const [salt, keyHex] = storedHash.split(":");
+
+  if (!salt || !keyHex) {
+    return false;
+  }
+
+  const derivedKey = scryptSync(password, salt, KEY_LENGTH);
+  const keyBuffer = Buffer.from(keyHex, "hex");
+
+  if (keyBuffer.length !== derivedKey.length) {
+    return false;
+  }
+
+  return timingSafeEqual(derivedKey, keyBuffer);
+}

--- a/pos-web-taller-ia/src/lib/prisma.js
+++ b/pos-web-taller-ia/src/lib/prisma.js
@@ -1,0 +1,11 @@
+import { PrismaClient } from "../../../generated/prisma";
+
+const globalForPrisma = globalThis;
+
+const prisma = globalForPrisma.__prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.__prisma = prisma;
+}
+
+export default prisma;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,6 +104,15 @@ model stores {
   sales     sales[]
 }
 
+model users {
+  user_id       Int      @id @default(autoincrement())
+  correo        String   @unique(map: "users_correo_key") @db.VarChar(191)
+  password      String   @db.VarChar(255)
+  activo        Boolean  @default(true)
+  nombreUsuario String   @map("nombre_usuario") @db.VarChar(120)
+  fechaCreacion DateTime @default(now()) @map("fecha_creacion") @db.DateTime(0)
+}
+
 enum promotions_promo_type {
   GENERAL
   PRODUCT


### PR DESCRIPTION
## Summary
- add a Prisma `users` model with email, hashed password, activation flag, and creation timestamp
- implement Next.js API routes for listing, creating, updating, deleting users, and logging in with port feedback
- share Prisma/auth utilities and replace the home page with a professional login experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddba40cdc8832f9a6b4aae9c29cd94