### PR TITLE
Fix Prisma MySQL connection and seed admin user

### DIFF
--- a/pos-web-taller-ia/.env.example
+++ b/pos-web-taller-ia/.env.example
@@ -1,0 +1,4 @@
+# Cadena de conexión para la base de datos MySQL utilizada por Prisma.
+# Reemplace los valores de usuario, contraseña, host, puerto y base de datos
+# según su entorno.
+DATABASE_URL="mysql://usuario:contraseña@localhost:3306/nombre_base"

--- a/pos-web-taller-ia/README.md
+++ b/pos-web-taller-ia/README.md
@@ -2,6 +2,14 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
+## Configuración previa
+
+1. Copia el archivo `.env.example` a `.env` y actualiza la variable `DATABASE_URL` con los datos de tu servidor MySQL.
+2. Instala las dependencias con `npm install`.
+3. Genera el cliente de Prisma con `npx prisma generate`.
+4. Sincroniza el esquema a la base de datos con `npx prisma db push`.
+5. (Opcional) Ejecuta `npm run db:seed` para asegurar la existencia del usuario administrador `admin@admin.com` con la contraseña `123456`.
+
 First, run the development server:
 
 ```bash

--- a/pos-web-taller-ia/package.json
+++ b/pos-web-taller-ia/package.json
@@ -1,6 +1,16 @@
 {
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "db:seed": "prisma db seed"
+  },
   "dependencies": {
     "@prisma/client": "^6.16.3",
     "prisma": "^6.16.3"
+  },
+  "prisma": {
+    "seed": "node prisma/seed.js"
   }
 }

--- a/pos-web-taller-ia/prisma/schema.prisma
+++ b/pos-web-taller-ia/prisma/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
   provider = "prisma-client-js"
-  output   = "../generated/prisma"
 }
 
 datasource db {

--- a/pos-web-taller-ia/prisma/seed.js
+++ b/pos-web-taller-ia/prisma/seed.js
@@ -1,0 +1,47 @@
+const { PrismaClient } = require("@prisma/client");
+const { randomBytes, scryptSync } = require("crypto");
+
+const prisma = new PrismaClient();
+const KEY_LENGTH = 64;
+
+function hashPassword(password) {
+  if (typeof password !== "string" || password.length < 6) {
+    throw new Error("La contraseña debe tener al menos 6 caracteres.");
+  }
+
+  const salt = randomBytes(16).toString("hex");
+  const derivedKey = scryptSync(password, salt, KEY_LENGTH);
+  return `${salt}:${derivedKey.toString("hex")}`;
+}
+
+async function upsertAdminUser() {
+  const correo = "admin@admin.com";
+  const password = "123456";
+
+  const hashedPassword = hashPassword(password);
+
+  await prisma.users.upsert({
+    where: { correo },
+    update: {},
+    create: {
+      correo,
+      password: hashedPassword,
+      nombreUsuario: "Administrador",
+      activo: true,
+    },
+  });
+}
+
+async function main() {
+  await upsertAdminUser();
+  console.log("Usuario administrador asegurado correctamente.");
+}
+
+main()
+  .catch((error) => {
+    console.error("Error al ejecutar el seed de Prisma", error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/pos-web-taller-ia/src/lib/auth.js
+++ b/pos-web-taller-ia/src/lib/auth.js
@@ -3,8 +3,8 @@ import { randomBytes, scryptSync, timingSafeEqual } from "crypto";
 const KEY_LENGTH = 64;
 
 export function hashPassword(password) {
-  if (typeof password !== "string" || password.length < 8) {
-    throw new Error("La contraseña debe tener al menos 8 caracteres.");
+  if (typeof password !== "string" || password.length < 6) {
+    throw new Error("La contraseña debe tener al menos 6 caracteres.");
   }
 
   const salt = randomBytes(16).toString("hex");

--- a/pos-web-taller-ia/src/lib/prisma.js
+++ b/pos-web-taller-ia/src/lib/prisma.js
@@ -1,4 +1,4 @@
-import { PrismaClient } from "../../../generated/prisma";
+import { PrismaClient } from "@prisma/client";
 
 const globalForPrisma = globalThis;
 


### PR DESCRIPTION
## Summary
- switch Prisma Client import to the default @prisma/client package and remove the custom output path
- document the required MySQL connection configuration, add an env template, and relax password length to support the provided admin account
- add a Prisma seed script and npm scripts to provision the admin@admin.com user automatically

## Testing
- npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68ddc9a1f9b8832f8537275a269c9b6d